### PR TITLE
Test implementation simulating the deadlock

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess2.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess2.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+public class TestingJobMasterServiceProcess2 implements JobMasterServiceProcess {
+
+    private final Supplier<CompletableFuture<Void>> closeAsyncSupplier;
+    private final Supplier<Boolean> isInitializedAndRunningSupplier;
+    private final Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier;
+    private final Supplier<CompletableFuture<JobManagerRunnerResult>> getResultFutureSupplier;
+    private final Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier;
+
+    public TestingJobMasterServiceProcess2(
+            Supplier<CompletableFuture<Void>> closeAsyncSupplier,
+            Supplier<Boolean> isInitializedAndRunningSupplier,
+            Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier,
+            Supplier<CompletableFuture<JobManagerRunnerResult>> getResultFutureSupplier,
+            Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier) {
+        this.closeAsyncSupplier = closeAsyncSupplier;
+        this.isInitializedAndRunningSupplier = isInitializedAndRunningSupplier;
+        this.getJobMasterGatewayFutureSupplier = getJobMasterGatewayFutureSupplier;
+        this.getResultFutureSupplier = getResultFutureSupplier;
+        this.getLeaderAddressFutureSupplier = getLeaderAddressFutureSupplier;
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        return closeAsyncSupplier.get();
+    }
+
+    @Override
+    public boolean isInitializedAndRunning() {
+        return isInitializedAndRunningSupplier.get();
+    }
+
+    @Override
+    public CompletableFuture<JobMasterGateway> getJobMasterGatewayFuture() {
+        return getJobMasterGatewayFutureSupplier.get();
+    }
+
+    @Override
+    public CompletableFuture<JobManagerRunnerResult> getResultFuture() {
+        return getResultFutureSupplier.get();
+    }
+
+    @Override
+    public CompletableFuture<String> getLeaderAddressFuture() {
+        return getLeaderAddressFutureSupplier.get();
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Supplier<CompletableFuture<Void>> closeAsyncSupplier = unsupportedOperation();
+        private Supplier<Boolean> isInitializedAndRunningSupplier = unsupportedOperation();
+        private Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier =
+                unsupportedOperation();
+        private Supplier<CompletableFuture<JobManagerRunnerResult>> getResultFutureSupplier =
+                unsupportedOperation();
+        private Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier =
+                unsupportedOperation();
+
+        private static <T> Supplier<T> unsupportedOperation() {
+            return () -> {
+                throw new UnsupportedOperationException();
+            };
+        }
+
+        public Builder setCloseAsyncSupplier(Supplier<CompletableFuture<Void>> closeAsyncSupplier) {
+            this.closeAsyncSupplier = closeAsyncSupplier;
+            return this;
+        }
+
+        public Builder setIsInitializedAndRunningSupplier(
+                Supplier<Boolean> isInitializedAndRunningSupplier) {
+            this.isInitializedAndRunningSupplier = isInitializedAndRunningSupplier;
+            return this;
+        }
+
+        public Builder setGetJobMasterGatewayFutureSupplier(
+                Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier) {
+            this.getJobMasterGatewayFutureSupplier = getJobMasterGatewayFutureSupplier;
+            return this;
+        }
+
+        public Builder setGetResultFutureSupplier(
+                Supplier<CompletableFuture<JobManagerRunnerResult>> getResultFutureSupplier) {
+            this.getResultFutureSupplier = getResultFutureSupplier;
+            return this;
+        }
+
+        public Builder setGetLeaderAddressFutureSupplier(
+                Supplier<CompletableFuture<String>> getLeaderAddressFutureSupplier) {
+            this.getLeaderAddressFutureSupplier = getLeaderAddressFutureSupplier;
+            return this;
+        }
+
+        public TestingJobMasterServiceProcess2 build() {
+            return new TestingJobMasterServiceProcess2(
+                    closeAsyncSupplier,
+                    isInitializedAndRunningSupplier,
+                    getJobMasterGatewayFutureSupplier,
+                    getResultFutureSupplier,
+                    getLeaderAddressFutureSupplier);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionDriver.java
@@ -38,18 +38,14 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
     private final LeaderElectionEventHandler leaderElectionEventHandler;
     private final FatalErrorHandler fatalErrorHandler;
 
-    private final Runnable beforeGrantLeadershipRunnable;
-
     // Leader information on external storage
     private LeaderInformation leaderInformation = LeaderInformation.empty();
 
     private TestingLeaderElectionDriver(
             LeaderElectionEventHandler leaderElectionEventHandler,
-            FatalErrorHandler fatalErrorHandler,
-            Runnable beforeGrantLeadershipRunnable) {
+            FatalErrorHandler fatalErrorHandler) {
         this.leaderElectionEventHandler = leaderElectionEventHandler;
         this.fatalErrorHandler = fatalErrorHandler;
-        this.beforeGrantLeadershipRunnable = beforeGrantLeadershipRunnable;
     }
 
     @Override
@@ -76,7 +72,6 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
     public void isLeader() {
         synchronized (lock) {
             isLeader.set(true);
-            beforeGrantLeadershipRunnable.run();
             leaderElectionEventHandler.onGrantLeadership(UUID.randomUUID());
         }
     }
@@ -102,22 +97,13 @@ public class TestingLeaderElectionDriver implements LeaderElectionDriver {
 
         private TestingLeaderElectionDriver currentLeaderDriver;
 
-        private Runnable beforeGrantLeadershipRunnable = () -> {};
-
-        public TestingLeaderElectionDriverFactory() {}
-
-        public TestingLeaderElectionDriverFactory(Runnable beforeGrantLeadershipRunnable) {
-            this.beforeGrantLeadershipRunnable = beforeGrantLeadershipRunnable;
-        }
-
         @Override
         public LeaderElectionDriver createLeaderElectionDriver(
                 LeaderElectionEventHandler leaderEventHandler,
                 FatalErrorHandler fatalErrorHandler,
                 String leaderContenderDescription) {
             currentLeaderDriver =
-                    new TestingLeaderElectionDriver(
-                            leaderEventHandler, fatalErrorHandler, beforeGrantLeadershipRunnable);
+                    new TestingLeaderElectionDriver(leaderEventHandler, fatalErrorHandler);
             return currentLeaderDriver;
         }
 


### PR DESCRIPTION
This PR is only a proposal to come up with the test implementation for PR apache/flink#21137. I noticed that the deadlock only occurs in a specific situation where the `JobMasterServiceProcess#closeAsync` returns an already completed future in [JobMasterServiceLeadershipRunner:145](https://github.com/apache/flink/blob/113299701cc0c41bf7fc4bbe86cebd3beea8dbe3/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java#L145). Only in that case will the follow-up task including the release of the `ClassLoaderLease` and stopping the `LeaderElectionService` be called within the synchronized block leading to the nested lock. That is why the test implementation became a bit trickier.

Additionally, I added a `TestingJobMasterServiceProcess2` implementation to have a more flexible test implementation for `JobMasterServiceProcess`. Actually, we shouldn't have two implementations but refactor `TestingJobMasterServiceProcess`, instead.